### PR TITLE
Default time format is hard coded to 24

### DIFF
--- a/packages/SettingsProvider/res/values/customize.xml
+++ b/packages/SettingsProvider/res/values/customize.xml
@@ -84,10 +84,10 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <integer name="def_voice_call_earpiece_volume" translatable="false">4</integer>
 
     <!-- Time format,default vlaue is 24 : 24 format,other value is 12 format -->
-    <string name="def_time_format" translatable="false">24</string>
+    <string name="def_time_format" translatable="false"></string>
 
     <!-- Date format,yyyy-MM-dd: 2013/07/30; MM-dd-yyyy:07/30/2013; dd-MM-yyyy:30/07/2013 -->
-    <string name="def_date_format" translatable="false">MM-dd-yyyy</string>
+    <string name="def_date_format" translatable="false"></string>
 
     <!--
          Default Input Method, its value is from inputmethod's package name and main class name

--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2403,11 +2403,16 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             loadIntegerSetting(stmt, Settings.System.POINTER_SPEED,
                     R.integer.def_pointer_speed);
 
-            loadStringSetting(stmt, Settings.System.TIME_12_24,
-                    R.string.def_time_format);
+            if (!TextUtils.isEmpty(mContext.getResources().getString(R.string.def_time_format))) {
+                loadStringSetting(stmt, Settings.System.TIME_12_24,
+                        R.string.def_time_format);
+            }
 
-            loadStringSetting(stmt, Settings.System.DATE_FORMAT,
-                    R.string.def_date_format);
+            if (!TextUtils.isEmpty(mContext.getResources().getString(R.string.def_date_format))) {
+                loadStringSetting(stmt, Settings.System.DATE_FORMAT,
+                        R.string.def_date_format);
+            }
+
         } finally {
             if (stmt != null) stmt.close();
         }


### PR DESCRIPTION
The items "def_time/date_format" will be hard coded for Default.
So should set "def_time/date_format" to be null in order to bring
back the AOSP implementation of picking the date format based on
the locale for Default

Change-Id: Ia5d74662782bcc00a8173fd49604f187a116468e