### PR TITLE
SlimDim: Use semaphore to cancel ontouch callback

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
@@ -113,6 +113,8 @@ public class NavigationBarView extends LinearLayout implements BaseStatusBar.Nav
     private boolean mImeArrowVisibility;
     private boolean mIsImeArrowVisible = false;
 
+    private boolean mIsHandlerCallbackActive = false;
+
     final Display mDisplay;
     View mCurrentView = null;
     View[] mRotatedViews = new View[4];
@@ -237,7 +239,10 @@ public class NavigationBarView extends LinearLayout implements BaseStatusBar.Nav
     };
 
     public void onNavButtonTouched() {
-        mHandler.removeCallbacks(mNavButtonDimmer);
+        if (mIsHandlerCallbackActive) {
+            mHandler.removeCallbacks(mNavButtonDimmer);
+            mIsHandlerCallbackActive = false;
+        }
         final boolean keyguardProbablyEnabled =
                 (mDisabledFlags & View.STATUS_BAR_DISABLE_HOME) != 0;
         if (getNavButtons() != null) {
@@ -250,6 +255,7 @@ public class NavigationBarView extends LinearLayout implements BaseStatusBar.Nav
             }
             if (mDimNavButtons && !keyguardProbablyEnabled) {
                 mHandler.postDelayed(mNavButtonDimmer, mDimNavButtonsTimeout);
+                mIsHandlerCallbackActive = true;
             }
         }
     }
@@ -1285,6 +1291,7 @@ public class NavigationBarView extends LinearLayout implements BaseStatusBar.Nav
     private Runnable mNavButtonDimmer = new Runnable() {
         @Override
         public void run() {
+            mIsHandlerCallbackActive = false;
             if (getNavButtons() != null && mIsDim == false) {
                 mIsDim = true;
                 if (mDimNavButtonsAnimate) {


### PR DESCRIPTION
Only cancel callback if there actually is a callback pending

PS3 : forgot to set semaphore to false in the runnable, once it's
      calledback, it's not scheduled anymore, no need to cancel it.

Change-Id: I205ccadb4afcf0f8ef4157b666d0df6161132c91
Signed-off-by: Jean-Pierre Rasquin <yank555.lu@gmail.com>