### PR TITLE
frameworks: fix up SlimAction shortcut icons (1/2)

### DIFF
--- a/core/java/com/android/internal/util/slim/ActionHelper.java
+++ b/core/java/com/android/internal/util/slim/ActionHelper.java
@@ -260,6 +260,7 @@ public class ActionHelper {
             resId = systemUiResources.getIdentifier(
                         SYSTEMUI_METADATA_NAME + ":drawable/ic_sysbar_recent", null, null);
         } else if (clickAction.equals(ActionConstants.ACTION_SEARCH)
+                || clickAction.equals(ActionConstants.ACTION_VOICE_SEARCH)
                 || clickAction.equals(ActionConstants.ACTION_ASSIST)
                 || clickAction.equals(ActionConstants.ACTION_KEYGUARD_SEARCH)) {
             resId = systemUiResources.getIdentifier(
@@ -318,6 +319,9 @@ public class ActionHelper {
         } else if (clickAction.equals(ActionConstants.ACTION_TORCH)) {
             resId = systemUiResources.getIdentifier(
                         SYSTEMUI_METADATA_NAME + ":drawable/ic_sysbar_torch", null, null);
+        } else if (clickAction.equals(ActionConstants.ACTION_CAMERA)) {
+            resId = systemUiResources.getIdentifier(
+                        SYSTEMUI_METADATA_NAME + ":drawable/ic_sysbar_camera", null, null);
         } else {
             resId = systemUiResources.getIdentifier(
                         SYSTEMUI_METADATA_NAME + ":drawable/ic_sysbar_null", null, null);

--- a/core/java/com/android/internal/util/slim/ImageHelper.java
+++ b/core/java/com/android/internal/util/slim/ImageHelper.java
@@ -74,6 +74,31 @@ public class ImageHelper {
         return bitmap;
     }
 
+    public static Bitmap drawableToShortcutIconBitmap (
+            Context context, Drawable drawable, int dp) {
+        if (drawable == null) {
+            return null;
+        } else if (drawable instanceof BitmapDrawable) {
+            return ((BitmapDrawable) drawable).getBitmap();
+        }
+
+        int size = Converter.dpToPx(context, dp);
+
+        // ensure that the drawable is not larger than target size
+        while (size < drawable.getIntrinsicHeight()
+                || size < drawable.getIntrinsicWidth()) {
+            size = size + 12;
+        }
+        Bitmap bitmap = Bitmap.createBitmap(size, size, Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds((size - drawable.getIntrinsicWidth()) / 2,
+                (size - drawable.getIntrinsicHeight()) / 2,
+                (size + drawable.getIntrinsicWidth()) / 2,
+                (size + drawable.getIntrinsicHeight()) / 2);
+        drawable.draw(canvas);
+        return bitmap;
+    }
+
     private static Bitmap toGrayscale(Bitmap bmpOriginal) {
         int width, height;
         height = bmpOriginal.getHeight();


### PR DESCRIPTION
patchset: ensure action icon is not larger than target

patchset: no need to create new immutable bitmap

patchset: use dp instead of px to properly size icon

patchset: icons for voice_search and camera already exist!
        tell the ActionHelper where to find them.

Change-Id: I641ffb4d2cc4f6045829a912a25902f8e113fa5d